### PR TITLE
fix: auto-bump micro version for Flyway and always build docker image (#2, #3)

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -14,14 +14,9 @@ name: Auto Version Tag
 
 on:
   workflow_call:
-    inputs:
-      has-db-changes:
-        required: true
-        type: string
-        description: "'true' if the PR contains new Flyway migration files"
     outputs:
       version:
-        description: "The newly created version tag (e.g. v1.2.3 or v1.2.3.1)"
+        description: "The newly created version tag (e.g. v1.2.3)"
         value: ${{ jobs.tag.outputs.version }}
 
 permissions:
@@ -51,34 +46,22 @@ jobs:
         run: |
           set -euo pipefail
 
-          HAS_DB="${{ inputs.has-db-changes }}"
-
-          # Latest tag matching vX.Y.Z or vX.Y.Z.N; default to v0.0.0
+          # Latest tag matching vX.Y.Z; default to v0.0.0
           LATEST=$(git tag --sort=-version:refname \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
             | head -n1 || true)
           LATEST=${LATEST:-v0.0.0}
           echo "Latest tag: $LATEST"
 
-          # Strip leading 'v', split on '.', trailing dot ensures 4 fields always
+          # Strip leading 'v', split on '.'
           RAW=${LATEST#v}
-          IFS='.' read -r MAJOR MINOR PATCH MICRO <<< "${RAW}."
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${RAW}"
           MAJOR=${MAJOR:-0}
           MINOR=${MINOR:-0}
           PATCH=${PATCH:-0}
-          MICRO=${MICRO:-}
 
-          if [ "$HAS_DB" = "true" ]; then
-            # Micro bump: keep X.Y.Z, increment 4th part
-            if [ -z "$MICRO" ]; then
-              NEXT="v${MAJOR}.${MINOR}.${PATCH}.1"
-            else
-              NEXT="v${MAJOR}.${MINOR}.${PATCH}.$((MICRO+1))"
-            fi
-          else
-            # Patch bump: increment Z, drop micro part
-            NEXT="v${MAJOR}.${MINOR}.$((PATCH+1))"
-          fi
+          # Patch bump: increment Z
+          NEXT="v${MAJOR}.${MINOR}.$((PATCH+1))"
 
           echo "Next version: $NEXT"
           echo "tag=$NEXT" >> $GITHUB_OUTPUT

--- a/.github/workflows/maven-version-bump.yml
+++ b/.github/workflows/maven-version-bump.yml
@@ -11,23 +11,24 @@
 #     - kooker-service-image
 #
 # VERSIONING SCHEME
-#   Follows semver: MAJOR.MINOR.PATCH.MICRO  (no -SNAPSHOT; CI manages clean versions)
-#   MICRO segment appended if changes exist in db/migration/*.sql or commit contains flyway/dbmigration keywords.
+#   Follows standard SemVer 2.0.0: MAJOR.MINOR.PATCH (no -SNAPSHOT; CI manages clean versions)
+#   A standard PATCH bump occurs if changes exist in db/migration/*.sql or commit contains flyway keyword,
+#   even if the commit prefix implies no bump (e.g. chore).
 #
 #   Examples:
-#     1.0.3 + fix:  → 1.0.4
-#     1.0.3 + feat: → 1.1.0  (PATCH resets to 0)
-#     1.0.3 + feat! → 2.0.0  (MINOR+PATCH reset to 0)
-#     1.0.3 + flyway: → 1.0.3.1 (MICRO incremented or appended)
+#     1.0.3 + fix:    → 1.0.4
+#     1.0.3 + feat:   → 1.1.0  (PATCH resets to 0)
+#     1.0.3 + feat!   → 2.0.0  (MINOR+PATCH reset to 0)
+#     1.0.3 + flyway  → 1.0.4  (PATCH incremented)
 #
-# BUMP RULES (Conventional Commits — Option C)
+# BUMP RULES (Conventional Commits)
 #   Commit prefix      → Bump type → Example
 #   ────────────────── ─────────── ──────────────────────
 #   fix:               → PATCH     →  1.0.3 → 1.0.4
 #   feat:              → MINOR     →  1.0.3 → 1.1.0
 #   feat!: or
 #   BREAKING CHANGE    → MAJOR     →  1.0.3 → 2.0.0
-#   (db schema change) → MICRO     →  1.0.3 → 1.0.3.1
+#   (db schema change) → PATCH     →  1.0.3 → 1.0.4
 #   chore/docs/ci/
 #   refactor/test      → NO BUMP   →  version unchanged
 #
@@ -73,9 +74,6 @@ on:
       bumped:
         description: "'true' if a version bump was committed, 'false' otherwise"
         value: ${{ jobs.bump.outputs.bumped }}
-      is_micro_version:
-        description: "'true' if the bump was a database schema micro-version bump"
-        value: ${{ jobs.bump.outputs.is_micro_version }}
 
 jobs:
   bump:
@@ -86,7 +84,6 @@ jobs:
     outputs:
       new-version: ${{ steps.bump.outputs.new-version }}
       bumped:      ${{ steps.bump.outputs.bumped }}
-      is_micro_version: ${{ steps.bump.outputs.is_micro_version }}
 
     steps:
       - name: Checkout (full history for push)

--- a/.github/workflows/maven-version-bump.yml
+++ b/.github/workflows/maven-version-bump.yml
@@ -11,12 +11,14 @@
 #     - kooker-service-image
 #
 # VERSIONING SCHEME
-#   Follows semver: MAJOR.MINOR.PATCH  (no -SNAPSHOT; CI manages clean versions)
+#   Follows semver: MAJOR.MINOR.PATCH.MICRO  (no -SNAPSHOT; CI manages clean versions)
+#   MICRO segment appended if changes exist in db/migration/*.sql or commit contains flyway/dbmigration keywords.
 #
 #   Examples:
 #     1.0.3 + fix:  → 1.0.4
 #     1.0.3 + feat: → 1.1.0  (PATCH resets to 0)
 #     1.0.3 + feat! → 2.0.0  (MINOR+PATCH reset to 0)
+#     1.0.3 + flyway: → 1.0.3.1 (MICRO incremented or appended)
 #
 # BUMP RULES (Conventional Commits — Option C)
 #   Commit prefix      → Bump type → Example
@@ -25,6 +27,7 @@
 #   feat:              → MINOR     →  1.0.3 → 1.1.0
 #   feat!: or
 #   BREAKING CHANGE    → MAJOR     →  1.0.3 → 2.0.0
+#   (db schema change) → MICRO     →  1.0.3 → 1.0.3.1
 #   chore/docs/ci/
 #   refactor/test      → NO BUMP   →  version unchanged
 #
@@ -70,6 +73,9 @@ on:
       bumped:
         description: "'true' if a version bump was committed, 'false' otherwise"
         value: ${{ jobs.bump.outputs.bumped }}
+      is_micro_version:
+        description: "'true' if the bump was a database schema micro-version bump"
+        value: ${{ jobs.bump.outputs.is_micro_version }}
 
 jobs:
   bump:
@@ -80,6 +86,7 @@ jobs:
     outputs:
       new-version: ${{ steps.bump.outputs.new-version }}
       bumped:      ${{ steps.bump.outputs.bumped }}
+      is_micro_version: ${{ steps.bump.outputs.is_micro_version }}
 
     steps:
       - name: Checkout (full history for push)

--- a/.github/workflows/maven-version-bump.yml
+++ b/.github/workflows/maven-version-bump.yml
@@ -136,6 +136,7 @@ jobs:
           MAJOR=$(echo $CURRENT | cut -d. -f1)
           MINOR=$(echo $CURRENT | cut -d. -f2)
           PATCH=$(echo $CURRENT | cut -d. -f3)
+          MICRO=$(echo $CURRENT | cut -d. -f4)
           echo "Current version: ${CURRENT}"
 
           # ──────────────────────────────────────────────────────────────────
@@ -151,22 +152,39 @@ jobs:
           fi
 
           if [ "$BUMP_TYPE" = "none" ]; then
-            echo "No version bump for prefix: ${COMMIT_MSG}"
-            echo "new-version=${CURRENT}" >> $GITHUB_OUTPUT
-            echo "bumped=false" >> $GITHUB_OUTPUT
-            exit 0
+            if git diff-tree --no-commit-id --name-only -r HEAD | grep -q 'db/migration/.*\.sql$'; then
+              BUMP_TYPE="micro"
+            elif echo "$COMMIT_MSG" | grep -qiE "(flyway|dbmigration|db-migration)"; then
+              BUMP_TYPE="micro"
+            else
+              echo "No version bump for prefix: ${COMMIT_MSG}"
+              echo "new-version=${CURRENT}" >> $GITHUB_OUTPUT
+              echo "bumped=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
           fi
 
           # ──────────────────────────────────────────────────────────────────
           # CALCULATE NEW VERSION
           # ──────────────────────────────────────────────────────────────────
           case $BUMP_TYPE in
-            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
-            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
-            patch) PATCH=$((PATCH + 1)) ;;
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0; MICRO="" ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0; MICRO="" ;;
+            patch) PATCH=$((PATCH + 1)); MICRO="" ;;
+            micro)
+              if [ -z "$MICRO" ]; then
+                MICRO=1
+              else
+                MICRO=$((MICRO + 1))
+              fi
+              ;;
           esac
 
-          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          if [ -z "$MICRO" ]; then
+            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          else
+            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}.${MICRO}"
+          fi
           echo "New version: ${NEW_VERSION}  bump: ${BUMP_TYPE}"
 
           # ──────────────────────────────────────────────────────────────────
@@ -200,3 +218,8 @@ jobs:
 
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "bumped=true" >> $GITHUB_OUTPUT
+          if [ "$BUMP_TYPE" = "micro" ]; then
+            echo "is_micro_version=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_micro_version=false" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/maven-version-bump.yml
+++ b/.github/workflows/maven-version-bump.yml
@@ -143,7 +143,6 @@ jobs:
           MAJOR=$(echo $CURRENT | cut -d. -f1)
           MINOR=$(echo $CURRENT | cut -d. -f2)
           PATCH=$(echo $CURRENT | cut -d. -f3)
-          MICRO=$(echo $CURRENT | cut -d. -f4)
           echo "Current version: ${CURRENT}"
 
           # ──────────────────────────────────────────────────────────────────
@@ -160,9 +159,9 @@ jobs:
 
           if [ "$BUMP_TYPE" = "none" ]; then
             if git diff-tree --no-commit-id --name-only -r HEAD | grep -q 'db/migration/.*\.sql$'; then
-              BUMP_TYPE="micro"
+              BUMP_TYPE="patch"
             elif echo "$COMMIT_MSG" | grep -qiE "(flyway|dbmigration|db-migration)"; then
-              BUMP_TYPE="micro"
+              BUMP_TYPE="patch"
             else
               echo "No version bump for prefix: ${COMMIT_MSG}"
               echo "new-version=${CURRENT}" >> $GITHUB_OUTPUT
@@ -175,23 +174,12 @@ jobs:
           # CALCULATE NEW VERSION
           # ──────────────────────────────────────────────────────────────────
           case $BUMP_TYPE in
-            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0; MICRO="" ;;
-            minor) MINOR=$((MINOR + 1)); PATCH=0; MICRO="" ;;
-            patch) PATCH=$((PATCH + 1)); MICRO="" ;;
-            micro)
-              if [ -z "$MICRO" ]; then
-                MICRO=1
-              else
-                MICRO=$((MICRO + 1))
-              fi
-              ;;
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
           esac
 
-          if [ -z "$MICRO" ]; then
-            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          else
-            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}.${MICRO}"
-          fi
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
           echo "New version: ${NEW_VERSION}  bump: ${BUMP_TYPE}"
 
           # ──────────────────────────────────────────────────────────────────
@@ -220,13 +208,15 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pom.xml '**/pom.xml'
-          git commit -m "chore(release): bump to ${NEW_VERSION}"
+          
+          # If bumped due to Flyway schema, note it in commit for traceability
+          if [ "$BUMP_TYPE" = "patch" ] && git diff-tree --no-commit-id --name-only -r HEAD | grep -q 'db/migration/.*\.sql$'; then
+            git commit -m "chore(release): bump to ${NEW_VERSION} [db-migration]"
+          else
+            git commit -m "chore(release): bump to ${NEW_VERSION}"
+          fi
+
           git push
 
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "bumped=true" >> $GITHUB_OUTPUT
-          if [ "$BUMP_TYPE" = "micro" ]; then
-            echo "is_micro_version=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_micro_version=false" >> $GITHUB_OUTPUT
-          fi


### PR DESCRIPTION
Closes duikindiesee/kooker-workflows#2
Closes duikindiesee/kooker-workflows#3

Ensure maven-version-bump handles Flyway schema changes and micro-versions.