### PR TITLE
feat: Automate GHCR 4-version retention & git releases

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -1,0 +1,32 @@
+# =============================================================================
+# ghcr-retention.yml
+# =============================================================================
+# PURPOSE
+#   Reusable workflow that trims GHCR images to maintain a rolling retention of 
+#   exactly 4 versions. This prevents snapshot feature tags and outdated branches 
+#   from exhausting the organization's physical storage limit incrementally.
+#
+# USAGE (in calling workflow)
+#   jobs:
+#     retention:
+#       uses: duikindiesee/kooker-workflows/.github/workflows/ghcr-retention.yml@main
+#       secrets: inherit
+# =============================================================================
+
+name: GHCR Centralized Retention (4 Versions)
+
+on:
+  workflow_call:
+
+jobs:
+  prune-ghcr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune old image tags
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ github.event.repository.name }}
+          package-type: 'container'
+          min-versions-to-keep: 4
+          # Standard PAT required for destructive package ops in GHCR
+          token: ${{ secrets.MAVEN_PUBLISH_TOKEN }}

--- a/.github/workflows/maven-version-bump.yml
+++ b/.github/workflows/maven-version-bump.yml
@@ -215,5 +215,8 @@ jobs:
 
           git push
 
+          echo "Generating automated GitHub Release v${NEW_VERSION}..."
+          gh release create "v${NEW_VERSION}" --title "Release v${NEW_VERSION}" --generate-notes
+
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "bumped=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Implements the core requirements for v1.5.4 architecture, specifically deleting old snapshot tags automatically retaining 4 max per service, and automating Github Release Notes off the semantic maven bumper.