### PR TITLE
fix(ci): Set explicit GitOps checkout target branch

### DIFF
--- a/.github/workflows/gitops-sync.yml
+++ b/.github/workflows/gitops-sync.yml
@@ -15,6 +15,11 @@ on:
         description: 'Path within kooker-infra to the kustomization.yaml directory'
         required: true
         type: string
+      target_branch:
+        description: 'Branch to checkout and push to in kooker-infra'
+        required: false
+        type: string
+        default: 'main'
 
 jobs:
   sync:
@@ -26,6 +31,7 @@ jobs:
           repository: duikindiesee/kooker-infra
           token: ${{ secrets.MAVEN_PUBLISH_TOKEN }}
           path: infra
+          ref: ${{ inputs.target_branch }}
 
       - name: Install Kustomize
         uses: imranismail/setup-kustomize@v2


### PR DESCRIPTION
ArgoCD applications source from develop or staging overlays which do not exist on the base main branch. This fixes the 'no such file or directory' errors in the kustomize checkout stage.