### PR TITLE
fix(ci): declare MAVEN_PUBLISH_TOKEN for secure retention logic

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -17,6 +17,9 @@ name: GHCR Centralized Retention (4 Versions)
 
 on:
   workflow_call:
+    secrets:
+      MAVEN_PUBLISH_TOKEN:
+        required: true
 
 permissions:
   packages: write


### PR DESCRIPTION
GHCR retention fails validation without explicitly declaring the required secret mapping upstream. Fixes #59 PR review.