### PR TITLE
feat(ci): v1.5.5 — node-version-bump workflow + bump-on-every-merge rule

### DIFF
--- a/.github/workflows/node-version-bump.yml
+++ b/.github/workflows/node-version-bump.yml
@@ -1,75 +1,55 @@
 # =============================================================================
-# maven-version-bump.yml
+# node-version-bump.yml
 # =============================================================================
 # PURPOSE
-#   Reusable workflow that automatically bumps the Maven project version in
-#   pom.xml based on the triggering commit message (Conventional Commits).
-#   Used by all Spring Boot backend services:
-#     - kooker-service-user
-#     - kooker-service-auth
-#     - kooker-gateway
-#     - kooker-service-image
+#   Reusable workflow that automatically bumps the npm package.json version on
+#   every merge to main. Used by all Node/frontend services:
+#     - kooker-pacman
+#     - kooker-web
+#     - sportifine-v2
+#     - kooker-api-specs
 #
 # VERSIONING SCHEME
-#   Follows standard SemVer 2.0.0: MAJOR.MINOR.PATCH (no -SNAPSHOT; CI manages clean versions)
-#   A standard PATCH bump occurs if changes exist in db/migration/*.sql or commit contains flyway keyword,
-#   even if the commit prefix implies no bump (e.g. chore).
-#
-#   Examples:
-#     1.0.3 + fix:    → 1.0.4
-#     1.0.3 + feat:   → 1.1.0  (PATCH resets to 0)
-#     1.0.3 + feat!   → 2.0.0  (MINOR+PATCH reset to 0)
-#     1.0.3 + flyway  → 1.0.4  (PATCH incremented)
+#   Follows standard SemVer 2.0.0: MAJOR.MINOR.PATCH
+#   Every non-release merge to main triggers at minimum a PATCH bump.
 #
 # BUMP RULES (Conventional Commits)
 #   Commit prefix      → Bump type → Example
 #   ────────────────── ─────────── ──────────────────────
-#   fix:               → PATCH     →  1.0.3 → 1.0.4
+#   feat!: / BREAKING  → MAJOR     →  1.0.3 → 2.0.0
 #   feat:              → MINOR     →  1.0.3 → 1.1.0
-#   feat!: or
-#   BREAKING CHANGE    → MAJOR     →  1.0.3 → 2.0.0
-#   (db schema change) → PATCH     →  1.0.3 → 1.0.4
-#   chore/docs/ci/
-#   refactor/test      → NO BUMP   →  version unchanged
+#   fix: / any other   → PATCH     →  1.0.3 → 1.0.4
 #
 # LOOP PREVENTION
 #   Bump commits use "chore(release):" prefix, detected on the next CI run
-#   to skip bumping. The Docker build continues in the same workflow run.
+#   to skip bumping. The Docker build still continues in the same run.
 #
 # USAGE (in calling workflow)
 #   jobs:
 #     version-bump:
-#       uses: duikindiesee/kooker-workflows/.github/workflows/maven-version-bump.yml@main
-#       with:
-#         java-version: '25'         # optional, default is '25'
+#       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+#       uses: duikindiesee/kooker-workflows/.github/workflows/node-version-bump.yml@main
 #       secrets: inherit
 #
-#     build:
+#     build-and-push:
 #       needs: version-bump
-#       # version: ${{ needs.version-bump.outputs.new-version }}
+#       # use: needs.version-bump.outputs.new-version for Docker tag
 #
 # REQUIRED PERMISSIONS (in calling workflow)
 #   permissions:
 #     contents: write
 #
 # REQUIRED SECRETS
-#   MAVEN_PUBLISH_TOKEN — PAT for reading from GitHub Packages (kooker-parent-build)
+#   GITHUB_TOKEN — standard token with contents: write
 # =============================================================================
 
-name: Maven Version Bump (Conventional Commits)
+name: Node Version Bump (Conventional Commits)
 
 on:
   workflow_call:
-    inputs:
-      java-version:
-        description: "JDK version to use for mvn help:evaluate and versions:set. Default: '25'."
-        required: false
-        type: string
-        default: '25'
-
     outputs:
       new-version:
-        description: "The Maven project version after the bump (or unchanged if no bump)"
+        description: "The package.json version after the bump (or unchanged if skipped)"
         value: ${{ jobs.bump.outputs.new-version }}
       bumped:
         description: "'true' if a version bump was committed, 'false' otherwise"
@@ -79,7 +59,7 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # needed to push the bump commit back to the branch
+      contents: write
 
     outputs:
       new-version: ${{ steps.bump.outputs.new-version }}
@@ -92,25 +72,15 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up JDK (needed for mvn help:evaluate and versions:set)
-        uses: actions/setup-java@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          java-version: ${{ inputs.java-version }}
-          distribution: temurin
-          cache: maven
-          server-id: github
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.MAVEN_PUBLISH_TOKEN }}
+          node-version: '20'
 
       - name: Detect bump type and apply version
         id: bump
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.MAVEN_PUBLISH_TOKEN }}
         run: |
+          set -euo pipefail
           COMMIT_MSG="${{ github.event.head_commit.message }}"
           echo "=== Commit: ${COMMIT_MSG}"
 
@@ -120,21 +90,18 @@ jobs:
           # ──────────────────────────────────────────────────────────────────
           if echo "$COMMIT_MSG" | grep -qE "^chore\(release\):"; then
             echo "Release commit detected — skipping bump to prevent infinite loop."
-            CURRENT=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null | tail -1)
+            CURRENT=$(node -p "require('./package.json').version")
             echo "new-version=${CURRENT}" >> $GITHUB_OUTPUT
             echo "bumped=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           # ──────────────────────────────────────────────────────────────────
-          # READ CURRENT VERSION from pom.xml via Maven (handles parent poms,
-          # property interpolation, multi-module layouts correctly).
-          # Strips -SNAPSHOT if present.
+          # READ CURRENT VERSION from package.json
           # ──────────────────────────────────────────────────────────────────
-          RAW=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null | tail -1)
-          CURRENT=${RAW%-SNAPSHOT}
+          CURRENT=$(node -p "require('./package.json').version")
           if [ -z "$CURRENT" ]; then
-            echo "ERROR: Could not read project.version from pom.xml" >&2
+            echo "ERROR: Could not read version from package.json" >&2
             exit 1
           fi
           MAJOR=$(echo $CURRENT | cut -d. -f1)
@@ -144,21 +111,14 @@ jobs:
 
           # ──────────────────────────────────────────────────────────────────
           # DETERMINE BUMP TYPE from Conventional Commit prefix.
-          # RULE: Every non-release merge to main triggers at minimum PATCH.
+          # Default to PATCH for any non-release merge (every merge bumps).
           # ──────────────────────────────────────────────────────────────────
           BUMP_TYPE="patch"
           if echo "$COMMIT_MSG" | grep -qiE "(^feat!|^feat\([^)]+\)!|BREAKING CHANGE)"; then
             BUMP_TYPE="major"
           elif echo "$COMMIT_MSG" | grep -qE "^feat(\([^)]+\))?:"; then
             BUMP_TYPE="minor"
-          elif git diff-tree --no-commit-id --name-only -r HEAD | grep -q 'db/migration/.*\.sql$'; then
-            BUMP_TYPE="patch"
-          elif echo "$COMMIT_MSG" | grep -qiE "(flyway|dbmigration|db-migration)"; then
-            BUMP_TYPE="patch"
           fi
-          # All other prefixes (fix:, chore:, ci:, refactor:, docs:, test:, etc.)
-          # fall through to the default PATCH bump above.
-          echo "Bump type: ${BUMP_TYPE}"
 
           # ──────────────────────────────────────────────────────────────────
           # CALCULATE NEW VERSION
@@ -173,47 +133,31 @@ jobs:
           echo "New version: ${NEW_VERSION}  bump: ${BUMP_TYPE}"
 
           # ──────────────────────────────────────────────────────────────────
-          # WRITE NEW VERSION to all pom.xml files via Maven Versions Plugin.
-          # -DgenerateBackupPoms=false avoids committing .versionsBackup files.
-          # Covers root pom + all submodules automatically.
+          # WRITE NEW VERSION to package.json via npm version
+          # --no-git-tag-version: we manage the git tag ourselves below
           # ──────────────────────────────────────────────────────────────────
-          mvn -B versions:set -DnewVersion="${NEW_VERSION}" -DgenerateBackupPoms=false
-
-          # ──────────────────────────────────────────────────────────────────
-          # SYNC OPENAPI SPEC VERSION (if present)
-          # Keeps postman/specs/openapi.yaml info.version in lockstep with the
-          # Maven artifact version. Only applies to services that have a spec.
-          # ──────────────────────────────────────────────────────────────────
-          SPEC_FILE="postman/specs/openapi.yaml"
-          if [ -f "${SPEC_FILE}" ]; then
-            # Match exactly two-space-indented version: line (the info.version field)
-            sed -i "s/^  version: .*/  version: ${NEW_VERSION}/" "${SPEC_FILE}"
-            git add "${SPEC_FILE}"
-            echo "Also bumped ${SPEC_FILE} to ${NEW_VERSION}"
-          fi
+          npm version "${NEW_VERSION}" --no-git-tag-version --allow-same-version
 
           # ──────────────────────────────────────────────────────────────────
           # COMMIT AND PUSH
           # ──────────────────────────────────────────────────────────────────
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pom.xml '**/pom.xml'
-          
-          # If bumped due to Flyway schema, note it in commit for traceability
-          if [ "$BUMP_TYPE" = "patch" ] && git diff-tree --no-commit-id --name-only -r HEAD | grep -q 'db/migration/.*\.sql$'; then
-            git commit -m "chore(release): bump to ${NEW_VERSION} [db-migration]"
-          else
-            git commit -m "chore(release): bump to ${NEW_VERSION}"
-          fi
-
+          git add package.json package-lock.json 2>/dev/null || git add package.json
+          git commit -m "chore(release): bump to ${NEW_VERSION}"
           git push
 
-          if [ "${GITHUB_REF}" = "refs/heads/main" ] || [ "${GITHUB_REF}" = "refs/heads/master" ]; then
-            echo "Generating automated GitHub Release v${NEW_VERSION}..."
-            gh release create "v${NEW_VERSION}" --title "Release v${NEW_VERSION}" --generate-notes
-          else
-            echo "Skipping GitHub Release generation since not on main branch (${GITHUB_REF})"
+          # ──────────────────────────────────────────────────────────────────
+          # CREATE GITHUB RELEASE (only on main)
+          # ──────────────────────────────────────────────────────────────────
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            echo "Creating GitHub Release v${NEW_VERSION}..."
+            gh release create "v${NEW_VERSION}" \
+              --title "Release v${NEW_VERSION}" \
+              --generate-notes
           fi
 
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "bumped=true" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Part of v1.5.5: guaranteed version bumping on every \main\ merge.

### Changes
- **NEW** \
ode-version-bump.yml\ — bumps package.json on every main merge for all Node repos
- **UPDATED** \maven-version-bump.yml\ — now bumps PATCH on every non-release merge (not just fix:/feat:)