### PR TITLE
fix(ci): remove contents: read from ghcr-retention.yml

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -23,7 +23,6 @@ on:
 
 permissions:
   packages: write
-  contents: read
 
 jobs:
   prune-ghcr:


### PR DESCRIPTION
The action delete-package-versions only needs packages: write. The contents: read was causing startup_failure in any caller workflow that does not explicitly grant contents permissions.