### PR TITLE
fix: remove duplicate env block in maven-version-bump causing Java startup_failure

### DIFF
--- a/.github/workflows/maven-version-bump.yml
+++ b/.github/workflows/maven-version-bump.yml
@@ -108,9 +108,6 @@ jobs:
 
       - name: Detect bump type and apply version
         id: bump
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.MAVEN_PUBLISH_TOKEN }}
         run: |
           COMMIT_MSG="${{ github.event.head_commit.message }}"
           echo "=== Commit: ${COMMIT_MSG}"


### PR DESCRIPTION
The bump step had two env: blocks which caused YAML parse error and startup_failure on all Java repos. Consolidated to single env block.