### PR TITLE
fix(maven-bump): restore GITHUB_ACTOR+MAVEN_PUBLISH_TOKEN for Maven c…

### DIFF
--- a/.github/workflows/maven-version-bump.yml
+++ b/.github/workflows/maven-version-bump.yml
@@ -208,6 +208,8 @@ jobs:
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "bumped=true" >> $GITHUB_OUTPUT
         env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.MAVEN_PUBLISH_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
This pull request makes a minor update to the Maven version bump GitHub Actions workflow by adding environment variables for authentication.

* Added `GITHUB_ACTOR` and `GITHUB_TOKEN` environment variables to the Maven version bump workflow in `.github/workflows/maven-version-bump.yml` to support authentication during workflow execution.