### PR TITLE
fix(bump): use PAT for PR creation so bump PRs trigger CI + auto-merge

### DIFF
--- a/.github/workflows/node-version-bump.yml
+++ b/.github/workflows/node-version-bump.yml
@@ -164,7 +164,10 @@ jobs:
         if: steps.bump.outputs.bumped == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # MUST use a PAT here — GITHUB_TOKEN commits do NOT trigger workflow
+          # runs on the created branch (GitHub loop-prevention). Without CI running
+          # on the bump PR, auto-merge can never fire.
+          token: ${{ secrets.MAVEN_PUBLISH_TOKEN }}
           branch: "chore/bump-${{ steps.bump.outputs.new-version }}"
           title: "chore(release): bump to ${{ steps.bump.outputs.new-version }}"
           body: |
@@ -174,6 +177,7 @@ jobs:
             Will auto-merge once status checks pass.
           labels: "automated,version-bump"
           delete-branch: true
+
 
       - name: Enable auto-merge on bump PR
         if: steps.create-pr.outputs.pull-request-number != ''


### PR DESCRIPTION
## Root Cause
\create-pull-request@v8\ was using \GITHUB_TOKEN\. GitHub blocks workflow run triggers on pushes/PRs made by \GITHUB_TOKEN\ to prevent infinite loops.

**Effect:** chore/bump PRs had ZERO CI checks. Auto-merge requires checks to pass, so it never fired. This caused kooker-pacman to stay pinned at 1.2.5 indefinitely.

## Fix
Switch \	oken:\ to \MAVEN_PUBLISH_TOKEN\ (PAT) for the \create-pull-request\ step only. Auto-merge and GitHub Release steps can still use \GITHUB_TOKEN\.