### PR TITLE
feat: neo4j delta cache reusable workflow for Joe's memory graph

### DIFF
--- a/.github/workflows/neo4j-delta-cache.yml
+++ b/.github/workflows/neo4j-delta-cache.yml
@@ -1,0 +1,138 @@
+name: Neo4j Delta Cache
+
+# Reusable workflow — call this from any repo's main push to cache changed files into Neo4j.
+# This powers Joe's (JoeHermesBot on Mac Mini 2) memory search and irwins_memory_bank graph queries.
+#
+# Usage in calling workflow:
+#   jobs:
+#     neo4j-cache:
+#       uses: duikindiesee/kooker-workflows/.github/workflows/neo4j-delta-cache.yml@main
+#       secrets: inherit
+#       with:
+#         repo-name: 'kooker-infra'   # optional
+
+on:
+  workflow_call:
+    inputs:
+      repo-name:
+        description: "Override repo name stored in graph (defaults to caller's github.repository basename)"
+        required: false
+        type: string
+    secrets:
+      NEO4J_PASSWORD:
+        description: "Neo4j HTTP password (stored as repo/org secret NEO4J_PASSWORD)"
+        required: true
+
+jobs:
+  cache-delta:
+    name: Cache delta to Neo4j
+    runs-on: [self-hosted, local-linux]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Resolve changed files
+        id: meta
+        run: |
+          REPO_INPUT="${{ inputs.repo-name }}"
+          REPO_NAME="${REPO_INPUT:-${GITHUB_REPOSITORY##*/}}"
+          SHA="${{ github.sha }}"
+          PARENT="${{ github.event.before }}"
+          MSG="$(git log -1 --pretty=%s)"
+
+          echo "repo=$REPO_NAME"   >> $GITHUB_OUTPUT
+          echo "sha=$SHA"          >> $GITHUB_OUTPUT
+          echo "message=$MSG"      >> $GITHUB_OUTPUT
+
+          # Delta: files changed between parent and this commit
+          if git cat-file -e "$PARENT^{commit}" 2>/dev/null; then
+            git diff --name-only "$PARENT" "$SHA" > /tmp/changed_files.txt
+          else
+            # First commit or force-push — index everything
+            git ls-files > /tmp/changed_files.txt
+          fi
+
+          echo "Files to cache: $(wc -l < /tmp/changed_files.txt)"
+          cat /tmp/changed_files.txt
+
+      - name: Upsert Commit node
+        env:
+          NEO4J_URL: "http://neo4j.kooker.co.za"
+          NEO4J_PASS: ${{ secrets.NEO4J_PASSWORD }}
+        run: |
+          REPO="${{ steps.meta.outputs.repo }}"
+          SHA="${{ steps.meta.outputs.sha }}"
+          MSG="${{ steps.meta.outputs.message }}"
+          TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          curl -sf -X POST "$NEO4J_URL/db/neo4j/tx/commit" \
+            -H "Content-Type: application/json" \
+            -u "neo4j:$NEO4J_PASS" \
+            -d "{\"statements\":[{
+              \"statement\": \"MERGE (r:Repo {name:\$repo}) MERGE (c:Commit {sha:\$sha}) SET c.message=\$msg, c.ts=\$ts, c.repo=\$repo MERGE (r)-[:HAS_COMMIT]->(c)\",
+              \"parameters\": {\"repo\":\"$REPO\",\"sha\":\"$SHA\",\"msg\":\"$(echo $MSG | sed 's/\"/\\\"/g')\",\"ts\":\"$TS\"}
+            }]}"
+
+      - name: Cache changed files
+        env:
+          NEO4J_URL: "http://neo4j.kooker.co.za"
+          NEO4J_PASS: ${{ secrets.NEO4J_PASSWORD }}
+        run: |
+          REPO="${{ steps.meta.outputs.repo }}"
+          SHA="${{ steps.meta.outputs.sha }}"
+
+          while IFS= read -r fp; do
+            [ -z "$fp" ] && continue
+            EXT="${fp##*.}"
+
+            # Knowledge-relevant file types only
+            case "$EXT" in
+              md|adoc|yaml|yml|java|ts|tsx|json|py|sh|kt|xml) ;;
+              *) continue ;;
+            esac
+
+            # Embed content for small docs/configs (< 50KB)
+            CONTENT_JSON='""'
+            if [ -f "$fp" ]; then
+              SIZE=$(wc -c < "$fp")
+              if [ "$SIZE" -lt 51200 ]; then
+                CONTENT_JSON=$(python3 -c "import sys,json; print(json.dumps(open('$fp').read()))" 2>/dev/null || echo '""')
+              fi
+            fi
+
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$NEO4J_URL/db/neo4j/tx/commit" \
+              -H "Content-Type: application/json" \
+              -u "neo4j:$NEO4J_PASS" \
+              -d "{\"statements\":[{
+                \"statement\": \"MERGE (r:Repo {name:\$repo}) MERGE (f:File {path:\$path,repo:\$repo}) SET f.ext=\$ext, f.sha=\$sha, f.content=\$content MERGE (r)-[:CONTAINS]->(f) WITH f MATCH (c:Commit {sha:\$sha}) MERGE (f)-[:CHANGED_IN]->(c)\",
+                \"parameters\": {\"repo\":\"$REPO\",\"path\":\"$fp\",\"ext\":\"$EXT\",\"sha\":\"$SHA\",\"content\":$CONTENT_JSON}
+              }]}")
+
+            echo "$HTTP_CODE $fp"
+          done < /tmp/changed_files.txt
+
+      # Special node: irwins_memory_bank — this is what Joe queries for context
+      - name: Sync Memory Bank node
+        if: ${{ hashFiles('docs/irwins_memory_bank.md') != '' }}
+        env:
+          NEO4J_URL: "http://neo4j.kooker.co.za"
+          NEO4J_PASS: ${{ secrets.NEO4J_PASSWORD }}
+        run: |
+          if grep -q "irwins_memory_bank" /tmp/changed_files.txt 2>/dev/null; then
+            echo "Memory bank changed — updating :Memory node in graph..."
+            CONTENT=$(python3 -c "import json; print(json.dumps(open('docs/irwins_memory_bank.md').read()))")
+            TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+            curl -sf -X POST "$NEO4J_URL/db/neo4j/tx/commit" \
+              -H "Content-Type: application/json" \
+              -u "neo4j:$NEO4J_PASS" \
+              -d "{\"statements\":[{
+                \"statement\": \"MERGE (m:Memory {name:'irwins_memory_bank'}) SET m.content=\$c, m.updatedAt=\$ts\",
+                \"parameters\": {\"c\":$CONTENT,\"ts\":\"$TS\"}
+              }]}"
+            echo "Memory node updated."
+          else
+            echo "Memory bank unchanged — skipping."
+          fi

--- a/.github/workflows/neo4j-delta-cache.yml
+++ b/.github/workflows/neo4j-delta-cache.yml
@@ -1,26 +1,47 @@
 name: Neo4j Delta Cache
 
-# Reusable workflow — call this from any repo's main push to cache changed files into Neo4j.
-# This powers Joe's (JoeHermesBot on Mac Mini 2) memory search and irwins_memory_bank graph queries.
+# Reusable workflow — call from any repo's push-to-main to delta-sync changed files into Neo4j.
+# All connection details are passed as inputs/secrets by the caller — nothing infrastructure-specific
+# is hardcoded here so this public repo stays clean.
 #
-# Usage in calling workflow:
+# Usage:
 #   jobs:
 #     neo4j-cache:
 #       uses: duikindiesee/kooker-workflows/.github/workflows/neo4j-delta-cache.yml@main
 #       secrets: inherit
 #       with:
-#         repo-name: 'kooker-infra'   # optional
+#         neo4j_base_url: ${{ vars.NEO4J_BASE_URL }}
+#         repo_name: 'kooker-infra'
 
 on:
   workflow_call:
     inputs:
-      repo-name:
-        description: "Override repo name stored in graph (defaults to caller's github.repository basename)"
+      neo4j_base_url:
+        description: "Neo4j HTTP base URL (e.g. https://neo4j.example.com)"
+        required: true
+        type: string
+      repo_name:
+        description: "Repo label stored in graph (defaults to caller's repo basename)"
+        required: false
+        type: string
+      base_sha:
+        description: "Base commit SHA for diff (defaults to github.event.before)"
+        required: false
+        type: string
+      head_sha:
+        description: "Head commit SHA (defaults to github.sha)"
+        required: false
+        type: string
+      commit_message:
+        description: "Commit message override"
         required: false
         type: string
     secrets:
+      NEO4J_USERNAME:
+        description: "Neo4j username"
+        required: true
       NEO4J_PASSWORD:
-        description: "Neo4j HTTP password (stored as repo/org secret NEO4J_PASSWORD)"
+        description: "Neo4j password"
         required: true
 
 jobs:
@@ -33,24 +54,26 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Resolve changed files
+      - name: Resolve metadata
         id: meta
         run: |
-          REPO_INPUT="${{ inputs.repo-name }}"
+          REPO_INPUT="${{ inputs.repo_name }}"
           REPO_NAME="${REPO_INPUT:-${GITHUB_REPOSITORY##*/}}"
-          SHA="${{ github.sha }}"
-          PARENT="${{ github.event.before }}"
-          MSG="$(git log -1 --pretty=%s)"
+          SHA="${{ inputs.head_sha || github.sha }}"
+          PARENT="${{ inputs.base_sha || github.event.before }}"
+          MSG="${{ inputs.commit_message || github.event.head_commit.message }}"
+          TS="${{ github.event.head_commit.timestamp || '$(date -u +%Y-%m-%dT%H:%M:%SZ)' }}"
 
           echo "repo=$REPO_NAME"   >> $GITHUB_OUTPUT
           echo "sha=$SHA"          >> $GITHUB_OUTPUT
+          echo "parent=$PARENT"    >> $GITHUB_OUTPUT
           echo "message=$MSG"      >> $GITHUB_OUTPUT
+          echo "ts=$TS"            >> $GITHUB_OUTPUT
 
-          # Delta: files changed between parent and this commit
+          # Delta: only files changed between parent and current commit
           if git cat-file -e "$PARENT^{commit}" 2>/dev/null; then
             git diff --name-only "$PARENT" "$SHA" > /tmp/changed_files.txt
           else
-            # First commit or force-push — index everything
             git ls-files > /tmp/changed_files.txt
           fi
 
@@ -59,25 +82,27 @@ jobs:
 
       - name: Upsert Commit node
         env:
-          NEO4J_URL: "http://neo4j.kooker.co.za"
+          NEO4J_URL: ${{ inputs.neo4j_base_url }}
+          NEO4J_USER: ${{ secrets.NEO4J_USERNAME }}
           NEO4J_PASS: ${{ secrets.NEO4J_PASSWORD }}
         run: |
           REPO="${{ steps.meta.outputs.repo }}"
           SHA="${{ steps.meta.outputs.sha }}"
           MSG="${{ steps.meta.outputs.message }}"
-          TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          TS="${{ steps.meta.outputs.ts }}"
 
           curl -sf -X POST "$NEO4J_URL/db/neo4j/tx/commit" \
             -H "Content-Type: application/json" \
-            -u "neo4j:$NEO4J_PASS" \
+            -u "$NEO4J_USER:$NEO4J_PASS" \
             -d "{\"statements\":[{
               \"statement\": \"MERGE (r:Repo {name:\$repo}) MERGE (c:Commit {sha:\$sha}) SET c.message=\$msg, c.ts=\$ts, c.repo=\$repo MERGE (r)-[:HAS_COMMIT]->(c)\",
-              \"parameters\": {\"repo\":\"$REPO\",\"sha\":\"$SHA\",\"msg\":\"$(echo $MSG | sed 's/\"/\\\"/g')\",\"ts\":\"$TS\"}
+              \"parameters\": {\"repo\":\"$REPO\",\"sha\":\"$SHA\",\"msg\":\"$(echo "$MSG" | sed 's/\"/\\\"/g')\",\"ts\":\"$TS\"}
             }]}"
 
       - name: Cache changed files
         env:
-          NEO4J_URL: "http://neo4j.kooker.co.za"
+          NEO4J_URL: ${{ inputs.neo4j_base_url }}
+          NEO4J_USER: ${{ secrets.NEO4J_USERNAME }}
           NEO4J_PASS: ${{ secrets.NEO4J_PASSWORD }}
         run: |
           REPO="${{ steps.meta.outputs.repo }}"
@@ -86,53 +111,48 @@ jobs:
           while IFS= read -r fp; do
             [ -z "$fp" ] && continue
             EXT="${fp##*.}"
-
-            # Knowledge-relevant file types only
             case "$EXT" in
               md|adoc|yaml|yml|java|ts|tsx|json|py|sh|kt|xml) ;;
               *) continue ;;
             esac
 
-            # Embed content for small docs/configs (< 50KB)
             CONTENT_JSON='""'
             if [ -f "$fp" ]; then
               SIZE=$(wc -c < "$fp")
               if [ "$SIZE" -lt 51200 ]; then
-                CONTENT_JSON=$(python3 -c "import sys,json; print(json.dumps(open('$fp').read()))" 2>/dev/null || echo '""')
+                CONTENT_JSON=$(python3 -c "import json; print(json.dumps(open('$fp').read()))" 2>/dev/null || echo '""')
               fi
             fi
 
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$NEO4J_URL/db/neo4j/tx/commit" \
               -H "Content-Type: application/json" \
-              -u "neo4j:$NEO4J_PASS" \
+              -u "$NEO4J_USER:$NEO4J_PASS" \
               -d "{\"statements\":[{
                 \"statement\": \"MERGE (r:Repo {name:\$repo}) MERGE (f:File {path:\$path,repo:\$repo}) SET f.ext=\$ext, f.sha=\$sha, f.content=\$content MERGE (r)-[:CONTAINS]->(f) WITH f MATCH (c:Commit {sha:\$sha}) MERGE (f)-[:CHANGED_IN]->(c)\",
                 \"parameters\": {\"repo\":\"$REPO\",\"path\":\"$fp\",\"ext\":\"$EXT\",\"sha\":\"$SHA\",\"content\":$CONTENT_JSON}
               }]}")
-
             echo "$HTTP_CODE $fp"
           done < /tmp/changed_files.txt
 
-      # Special node: irwins_memory_bank — this is what Joe queries for context
-      - name: Sync Memory Bank node
+      - name: Sync Memory Bank node (if changed)
         if: ${{ hashFiles('docs/irwins_memory_bank.md') != '' }}
         env:
-          NEO4J_URL: "http://neo4j.kooker.co.za"
+          NEO4J_URL: ${{ inputs.neo4j_base_url }}
+          NEO4J_USER: ${{ secrets.NEO4J_USERNAME }}
           NEO4J_PASS: ${{ secrets.NEO4J_PASSWORD }}
         run: |
           if grep -q "irwins_memory_bank" /tmp/changed_files.txt 2>/dev/null; then
-            echo "Memory bank changed — updating :Memory node in graph..."
+            echo "Memory bank changed — updating :Memory node..."
             CONTENT=$(python3 -c "import json; print(json.dumps(open('docs/irwins_memory_bank.md').read()))")
             TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
             curl -sf -X POST "$NEO4J_URL/db/neo4j/tx/commit" \
               -H "Content-Type: application/json" \
-              -u "neo4j:$NEO4J_PASS" \
+              -u "$NEO4J_USER:$NEO4J_PASS" \
               -d "{\"statements\":[{
                 \"statement\": \"MERGE (m:Memory {name:'irwins_memory_bank'}) SET m.content=\$c, m.updatedAt=\$ts\",
                 \"parameters\": {\"c\":$CONTENT,\"ts\":\"$TS\"}
               }]}"
-            echo "Memory node updated."
+            echo "Done."
           else
             echo "Memory bank unchanged — skipping."
           fi


### PR DESCRIPTION
## Neo4j Delta Cache Workflow

This reusable workflow is called by any repo on `push` to `main`. It:

1. **Resolves changed files** using `git diff` between the parent and current commit (delta only — not full re-index)
2. **Upserts a `:Commit` node** in Neo4j with SHA, message, timestamp, and repo
3. **Indexes each changed file** as a `:File` node linked to the commit — embeds content for files < 50KB (`.md`, `.yaml`, `.java`, `.ts`, etc.)
4. **Special case: `irwins_memory_bank.md`** — synced to a dedicated `:Memory` node that Joe queries for cross-session context

### How Joe uses this
Joe (JoeHermesBot on Mac Mini 2) queries the Neo4j instance via HTTP. Example Cypher:
```cypher
// Get latest memory context
MATCH (m:Memory {name: 'irwins_memory_bank'}) RETURN m.content

// Find all files changed in kooker-infra in last 7 days
MATCH (f:File)-[:CHANGED_IN]->(c:Commit {repo:'kooker-infra'})
WHERE c.ts > datetime() - duration('P7D')
RETURN f.path, c.message ORDER BY c.ts DESC
```

### Required Secrets & Variables
Set these at org level in GitHub Settings → Secrets and Variables → Actions:
- `NEO4J_USERNAME` — org secret
- `NEO4J_PASSWORD` — org secret
- `NEO4J_BASE_URL` — org variable (not sensitive)
