### PR TITLE
fix(ci): keep commit messages out of generated shell scripts

### DIFF
--- a/.github/workflows/android-version-bump.yml
+++ b/.github/workflows/android-version-bump.yml
@@ -94,11 +94,10 @@ jobs:
       - name: Detect bump type and apply version
         id: bump
         run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
-          APP_DIR="${{ inputs.app-dir }}"
+          COMMIT_SUBJECT="$(printf '%s' "${COMMIT_MSG}" | sed -n '1p')"
           BUILD_GRADLE="${APP_DIR}/app/build.gradle"
 
-          echo "=== Commit  : ${COMMIT_MSG}"
+          printf '=== Commit  : %s\n' "${COMMIT_SUBJECT}"
           echo "=== App dir : ${APP_DIR}"
           echo "=== Gradle  : ${BUILD_GRADLE}"
 
@@ -146,7 +145,7 @@ jobs:
           fi
 
           if [ "$BUMP_TYPE" = "none" ]; then
-            echo "No version bump for prefix: ${COMMIT_MSG}"
+            echo "No version bump for prefix: ${COMMIT_SUBJECT}"
             echo "new-version=${CURRENT}" >> $GITHUB_OUTPUT
             echo "new-version-code=$(( MAJOR * 100 + MINOR * 10 + PATCH ))" >> $GITHUB_OUTPUT
             echo "bumped=false" >> $GITHUB_OUTPUT
@@ -186,3 +185,6 @@ jobs:
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "new-version-code=${NEW_CODE}" >> $GITHUB_OUTPUT
           echo "bumped=true" >> $GITHUB_OUTPUT
+        env:
+          APP_DIR: ${{ inputs.app-dir }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}

--- a/.github/workflows/maven-version-bump.yml
+++ b/.github/workflows/maven-version-bump.yml
@@ -111,8 +111,8 @@ jobs:
       - name: Detect bump type and apply version
         id: bump
         run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
-          echo "=== Commit: ${COMMIT_MSG}"
+          COMMIT_SUBJECT="$(printf '%s' "${COMMIT_MSG}" | sed -n '1p')"
+          printf '=== Commit: %s\n' "${COMMIT_SUBJECT}"
 
           # ──────────────────────────────────────────────────────────────────
           # LOOP GUARD
@@ -210,6 +210,7 @@ jobs:
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "bumped=true" >> $GITHUB_OUTPUT
         env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.MAVEN_PUBLISH_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/neo4j-delta-cache.yml
+++ b/.github/workflows/neo4j-delta-cache.yml
@@ -59,17 +59,15 @@ jobs:
       - name: Resolve metadata
         id: meta
         run: |
-          REPO_INPUT="${{ inputs.repo_name }}"
           REPO_NAME="${REPO_INPUT:-${GITHUB_REPOSITORY##*/}}"
-          SHA="${{ inputs.head_sha || github.sha }}"
-          PARENT="${{ inputs.base_sha || github.event.before }}"
-          MSG="${{ inputs.commit_message || github.event.head_commit.message }}"
-          TS="${{ github.event.head_commit.timestamp || '$(date -u +%Y-%m-%dT%H:%M:%SZ)' }}"
+          SHA="${HEAD_SHA}"
+          PARENT="${BASE_SHA}"
+          TS="${COMMIT_TS:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+          printf '%s' "${COMMIT_MSG}" > /tmp/commit_message.txt
 
           echo "repo=$REPO_NAME"   >> $GITHUB_OUTPUT
           echo "sha=$SHA"          >> $GITHUB_OUTPUT
           echo "parent=$PARENT"    >> $GITHUB_OUTPUT
-          echo "message=$MSG"      >> $GITHUB_OUTPUT
           echo "ts=$TS"            >> $GITHUB_OUTPUT
 
           # Delta: only files changed between parent and current commit
@@ -81,6 +79,12 @@ jobs:
 
           echo "Files to cache: $(wc -l < /tmp/changed_files.txt)"
           cat /tmp/changed_files.txt
+        env:
+          BASE_SHA: ${{ inputs.base_sha || github.event.before }}
+          COMMIT_MSG: ${{ inputs.commit_message || github.event.head_commit.message }}
+          COMMIT_TS: ${{ github.event.head_commit.timestamp }}
+          HEAD_SHA: ${{ inputs.head_sha || github.sha }}
+          REPO_INPUT: ${{ inputs.repo_name }}
 
       - name: Upsert Commit node
         env:
@@ -90,8 +94,8 @@ jobs:
         run: |
           REPO="${{ steps.meta.outputs.repo }}"
           SHA="${{ steps.meta.outputs.sha }}"
-          MSG="${{ steps.meta.outputs.message }}"
           TS="${{ steps.meta.outputs.ts }}"
+          MSG="$(cat /tmp/commit_message.txt)"
 
           PAYLOAD=$(jq -n \
             --arg repo "$REPO" \

--- a/.github/workflows/node-version-bump.yml
+++ b/.github/workflows/node-version-bump.yml
@@ -89,8 +89,8 @@ jobs:
         id: bump
         run: |
           set -euo pipefail
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
-          echo "=== Commit: ${COMMIT_MSG}"
+          COMMIT_SUBJECT="$(printf '%s' "${COMMIT_MSG}" | sed -n '1p')"
+          printf '=== Commit: %s\n' "${COMMIT_SUBJECT}"
 
           # ──────────────────────────────────────────────────────────────────
           # LOOP GUARD
@@ -167,6 +167,7 @@ jobs:
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "bumped=true" >> $GITHUB_OUTPUT
         env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- pass commit messages into reusable workflows via step env instead of inline Bash interpolation
- preserve existing Node/Maven/Android version bump rules and outputs
- store Neo4j cache commit messages in a temp file instead of multiline step outputs

## Verification
- confirmed failed kooker-web run 26474753461 died because a multiline commit body was injected into the generated Bash script
- ran bash smoke tests for patch/minor/major classification with multiline commit messages
- ran git diff --check