### PR TITLE
fix(release): node-version-bump skips already-cut versions to prevent pipeline jams

### DIFF
--- a/.github/workflows/node-version-bump.yml
+++ b/.github/workflows/node-version-bump.yml
@@ -1,5 +1,5 @@
 # =============================================================================
-# node-version-bump.yml  (v1.5.6)
+# node-version-bump.yml  (v1.5.7)
 # =============================================================================
 # PURPOSE
 #   Reusable workflow that automatically bumps the npm package.json version on
@@ -151,6 +151,22 @@ jobs:
           echo "New version: ${NEW_VERSION}  bump: ${BUMP_TYPE}"
 
           # ──────────────────────────────────────────────────────────────────
+          # SKIP ALREADY-CUT VERSIONS (self-heal from version drift)
+          # A bump PR can stall on failing CI, leaving package.json behind while
+          # its release tag was already created eagerly below. Without this guard
+          # every later merge recomputes the SAME version and "gh release create"
+          # fails on the existing tag, jamming the whole pipeline (the 0.17.0 and
+          # 0.22.6 incidents). Advance the patch until the version tag is free.
+          # ──────────────────────────────────────────────────────────────────
+          git fetch --tags --force --quiet || true
+          while git rev-parse -q --verify "refs/tags/v${NEW_VERSION}" >/dev/null 2>&1; do
+            echo "Tag v${NEW_VERSION} already exists; advancing patch."
+            PATCH=$((PATCH + 1))
+            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          done
+          echo "Resolved free version: ${NEW_VERSION}"
+
+          # ──────────────────────────────────────────────────────────────────
           # WRITE NEW VERSION to package.json
           # ──────────────────────────────────────────────────────────────────
           npm version "${NEW_VERSION}" --no-git-tag-version --allow-same-version
@@ -225,8 +241,14 @@ jobs:
       - name: Create GitHub Release
         if: steps.bump.outputs.bumped == 'true'
         run: |
-          gh release create "v${{ steps.bump.outputs.new-version }}" \
-            --title "Release v${{ steps.bump.outputs.new-version }}" \
-            --generate-notes
+          # Idempotent: the skip-existing-tags guard above already resolves a free
+          # version, but re-check here so a rare race never fails the release step.
+          if gh release view "v${{ steps.bump.outputs.new-version }}" >/dev/null 2>&1; then
+            echo "::warning::Release v${{ steps.bump.outputs.new-version }} already exists; skipping creation."
+          else
+            gh release create "v${{ steps.bump.outputs.new-version }}" \
+              --title "Release v${{ steps.bump.outputs.new-version }}" \
+              --generate-notes
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the recurring release-pipeline jam that just took citylife's deploy down (and took 0.17.0 down before it).

Root cause
node-version-bump creates the GitHub release and its git tag eagerly, at bump time, and gh release create is not idempotent. The bump PR that advances package.json to match is created separately and auto-merges only if its CI passes. When that bump PR stalls on a failing check (a flaky test, a branch-protection hiccup), the tag is already cut but package.json stays behind. Every subsequent merge then recomputes the exact same version, hits gh release create on the existing tag, and fails the whole version-bump job, which cascades to Docker and the GitOps deploy. That is precisely how citylife got stuck re-attempting v0.22.6.

Change
- The bump step fetches tags and advances the patch until it reaches a version whose tag does not yet exist, so it self-heals past any drift and never collides on release creation.
- The Create GitHub Release step is made idempotent as a race safety net, warning and continuing instead of failing if the release already exists.
- Header bumped to v1.5.7.

Blast radius and safety
This is the shared reusable workflow used by citylife, kooker-web, sportifine-v2, kooker-api-specs and others. On the happy path there is no behavior change, the first candidate version is always free, so the skip loop runs zero times and the release create path is unchanged. It only activates when a version was already cut, which is exactly the failure it repairs.

Immediate note for citylife
Its package.json is already at 0.22.6 now, so the next push to citylife main will cleanly cut 0.22.7 and deploy Jack's avatar loader and the pillar spec, with or without this fix. This fix stops the drift from ever jamming the pipeline again.

Route to MoJoJo.

Actor claude on kooker1
