### PR TITLE
fix(release): approve bump PRs and make releases idempotent in the maven pipeline

### DIFF
--- a/.github/workflows/maven-version-bump.yml
+++ b/.github/workflows/maven-version-bump.yml
@@ -175,6 +175,22 @@ jobs:
           echo "New version: ${NEW_VERSION}  bump: ${BUMP_TYPE}"
 
           # ──────────────────────────────────────────────────────────────────
+          # SKIP ALREADY-CUT VERSIONS (self-heal from version drift)
+          # A bump PR can stall, leaving pom.xml behind while its release tag was
+          # already cut below. Without this guard every later merge recomputes the
+          # SAME version and "gh release create" fails on the existing tag, jamming
+          # the whole pipeline. Advance the patch until the version tag is free.
+          # Mirrors the node-version-bump fix (kooker-workflows #46).
+          # ──────────────────────────────────────────────────────────────────
+          git fetch --tags --force --quiet || true
+          while git rev-parse -q --verify "refs/tags/v${NEW_VERSION}" >/dev/null 2>&1; do
+            echo "Tag v${NEW_VERSION} already exists; advancing patch."
+            PATCH=$((PATCH + 1))
+            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          done
+          echo "Resolved free version: ${NEW_VERSION}"
+
+          # ──────────────────────────────────────────────────────────────────
           # WRITE NEW VERSION to all pom.xml files via Maven Versions Plugin.
           # -DgenerateBackupPoms=false avoids committing .versionsBackup files.
           # Covers root pom + all submodules automatically.
@@ -246,11 +262,43 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # ──────────────────────────────────────────────────────────────────────
+      # APPROVE the bump PR with a SEPARATE identity so the armed auto-merge can
+      # complete under the main branch ruleset (which requires one non-author
+      # approval). The PR is authored by github-actions[bot]; GITOPS_APPROVER_TOKEN
+      # is a different account, so its review satisfies the rule. Without this the
+      # bump PR stalls REVIEW_REQUIRED forever, the pom never advances, and every
+      # later merge recomputes the same version and jams the release step. The
+      # merge itself is left to the auto-merge above (GITHUB_TOKEN), which does not
+      # re-trigger CI, so build-and-push runs exactly once in this same run and
+      # picks up the merged pom. Mirrors the gitops-sync approver (#45).
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Approve bump PR (separate approver identity)
+        if: steps.create-pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITOPS_APPROVER_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::GITOPS_APPROVER_TOKEN is not set. Bump PR #${{ steps.create-pr.outputs.pull-request-number }} opened but cannot be approved; it will stall under branch protection and jam the release pipeline."
+            exit 1
+          fi
+          gh pr review "${{ steps.create-pr.outputs.pull-request-number }}" \
+            --approve \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "Automated version bump. Approved by the separate approver identity so the armed auto-merge can complete under branch protection."
+
       - name: Create GitHub Release
         if: steps.bump.outputs.bumped == 'true'
         run: |
-          gh release create "v${{ steps.bump.outputs.new-version }}" \
-            --title "Release v${{ steps.bump.outputs.new-version }}" \
-            --generate-notes
+          # Idempotent: the skip-existing-tags guard above already resolves a free
+          # version, but re-check here so a rare race never fails the release step
+          # (mirror of node-version-bump #46).
+          if gh release view "v${{ steps.bump.outputs.new-version }}" >/dev/null 2>&1; then
+            echo "::warning::Release v${{ steps.bump.outputs.new-version }} already exists; skipping creation."
+          else
+            gh release create "v${{ steps.bump.outputs.new-version }}" \
+              --title "Release v${{ steps.bump.outputs.new-version }}" \
+              --generate-notes
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why
The maven version-bump reusable workflow (used by kooker-service-ai and every Java service) opens the bump PR as github-actions[bot] and only enables auto-merge. Under the main ruleset that requires one approval, nothing approves it, so the bump PR stalls REVIEW_REQUIRED, the pom never advances, and every later merge recomputes the same version and fails on the non-idempotent gh release create. This is what jammed kooker-service-ai for days.

kooker-workflows #46 fixed only the node twin; this mirrors both fixes into the maven twin.

## Changes
- **Approver step (mirror of #45):** approve the bump PR with GITOPS_APPROVER_TOKEN, a separate account from the github-actions author, so the already-armed auto-merge completes under branch protection. Fail-loud if the secret is missing. Merge stays on the GITHUB_TOKEN auto-merge, which does not re-trigger CI, so build-and-push runs once in the same run and picks up the merged pom.
- **Idempotency (mirror of #46):** advance the patch past already-cut tags before writing the version, and guard gh release create so an existing release is skipped instead of failing.

## Effect
Bump PRs self-approve and merge; the pom advances; releases stop colliding. The pipeline is self-healing again, fleet-wide, without weakening the ruleset. No behavior change for repos that already have GITOPS_APPROVER_TOKEN set org-wide.