### PR TITLE
fix(release): approve node bump PRs so they stop piling up

### DIFF
--- a/.github/workflows/node-version-bump.yml
+++ b/.github/workflows/node-version-bump.yml
@@ -238,6 +238,29 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # ──────────────────────────────────────────────────────────────────────
+      # APPROVE the bump PR with a SEPARATE identity so the armed auto-merge can
+      # complete under the main branch ruleset (which requires one non-author
+      # approval). Without this the bump PR stalls REVIEW_REQUIRED, package.json
+      # never advances, and every later merge recomputes a new version, so the
+      # bumps pile up and consecutive ones conflict. The PR is authored by
+      # MAVEN_PUBLISH_TOKEN; GITOPS_APPROVER_TOKEN is a different account, so its
+      # review satisfies the rule. Mirrors the maven twin (#47) and gitops-sync.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Approve bump PR (separate approver identity)
+        if: steps.create-pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITOPS_APPROVER_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::GITOPS_APPROVER_TOKEN is not set. Bump PR #${{ steps.create-pr.outputs.pull-request-number }} opened but cannot be approved; it will stall under branch protection and the bumps will pile up."
+            exit 1
+          fi
+          gh pr review "${{ steps.create-pr.outputs.pull-request-number }}" \
+            --approve \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "Automated version bump. Approved by the separate approver identity so the armed auto-merge can complete under branch protection."
+
       - name: Create GitHub Release
         if: steps.bump.outputs.bumped == 'true'
         run: |


### PR DESCRIPTION
## Why
`node-version-bump` (kooker-web, citylife, every JS service) enables auto-merge on the bump PR but nothing approves it. Under the main ruleset requiring one approval, the bump PR stalls `REVIEW_REQUIRED`, package.json never advances, and each later merge recomputes a new version — so the bumps **pile up and conflict** (kooker-web already has 0.106.0 + 0.106.1 stacked, the second dirty; this is what 'versions piling up' and citylife 'same version every time' both are).

The maven twin got this in #47; this mirrors it into node.

## Change
Adds an approve step using `GITOPS_APPROVER_TOKEN` (a different account than the `MAVEN_PUBLISH_TOKEN` author) after the auto-merge enable, so the armed auto-merge completes. Fail-loud if the secret is missing. Node already has #46's idempotency.

## Effect
Node bump PRs self-approve and merge; versions advance one clean step per merge; no more pile-ups — fleet-wide, no per-repo change.