### PR TITLE
fix(gitops): reject missing container images

### DIFF
--- a/.github/workflows/gitops-sync.yml
+++ b/.github/workflows/gitops-sync.yml
@@ -39,6 +39,42 @@ jobs:
     # runs-on: [self-hosted, local-linux]
     runs-on: ubuntu-latest
     steps:
+      - name: Validate the immutable image reference
+        id: image
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+          NEW_TAG: ${{ inputs.new_tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$IMAGE_NAME" =~ ^ghcr\.io/[a-z0-9_.-]+/[a-z0-9_./-]+$ ]]; then
+            echo "::error::image_name must be a lowercase ghcr.io image path"
+            exit 1
+          fi
+          if [[ ! "$NEW_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "::error::new_tag is not a valid OCI tag"
+            exit 1
+          fi
+          echo "reference=${IMAGE_NAME}:${NEW_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to GHCR for release proof
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.MAVEN_PUBLISH_TOKEN }}
+
+      - name: Set up Buildx for registry inspection
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prove the exact image exists before changing GitOps
+        shell: bash
+        env:
+          IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "$IMAGE_REFERENCE"
+
       - name: Checkout kooker-infra
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## What
- validate GHCR image names and OCI tags before touching GitOps
- authenticate and inspect the exact immutable image reference
- fail before checkout, branch creation, or deploy PR when the image is absent

## Why
Service User's release workflow published `1.26.0` while GitOps pinned nonexistent `1.26.1`, leaving Argo's migration hook in ImagePullBackOff for three days. The shared deploy boundary must reject this class of false-green release for every caller.

## Verification
- `actionlint .github/workflows/gitops-sync.yml`
- YAML parse
- `git diff --check`

## Gate
MoJoJo review/merge required. This PR changes the shared reusable deployment workflow and does not itself deploy anything.