### PR TITLE
fix(ci): run Maven version bump on kooker1 org runner

### DIFF
--- a/.github/workflows/maven-version-bump.yml
+++ b/.github/workflows/maven-version-bump.yml
@@ -79,9 +79,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   bump:
-    # Migrated to GitHub-hosted cloud runner. Self-hosted runner config preserved below.
-    # runs-on: [self-hosted, local-linux]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
     permissions:
       contents: write
       pull-requests: write  # needed to push the bump commit back to the branch


### PR DESCRIPTION
Moves the reusable Maven version-bump job from GitHub-hosted ubuntu-latest to the approved organization runner labels: self-hosted, Linux, X64, kooker1-org, docker. This is a one-workflow runner-selector change needed to unblock the kooker-service-ai PR 266 release. Verification: git diff --check passed; exact-label assertion found one matching runs-on line and zero remaining ubuntu-latest references. No merge performed.