### PR TITLE
fix(ci): run Node version bump on kooker1 org runner

### DIFF
--- a/.github/workflows/node-version-bump.yml
+++ b/.github/workflows/node-version-bump.yml
@@ -64,9 +64,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   bump:
-    # Migrated to GitHub-hosted cloud runner. Self-hosted runner config preserved below.
-    # runs-on: [self-hosted, local-linux]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Moves only the reusable Node version-bump job from GitHub-hosted ubuntu-latest to the approved organization runner selector: self-hosted, Linux, X64, kooker1-org, docker. This is required for the kooker-web PR #455 post-merge release. Exact commit: 7701b6cfe254b98db0782343f0b5455dac73ab07. Verification: git diff --check passed; one changed workflow (1 insertion, 3 deletions); static assertion found exactly one approved runs-on selector and no ubuntu-latest selector; pinned Prettier 3.6.2 parsed the YAML successfully. No merge performed.