### PR TITLE
fix(ci): run deploy and retention on org runners

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -46,9 +46,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   prune-ghcr:
-    # Migrated to GitHub-hosted cloud runner. Self-hosted runner config preserved below.
-    # runs-on: [self-hosted, local-linux]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
     steps:
       - name: Prune old image tags
         uses: actions/delete-package-versions@v5

--- a/.github/workflows/gitops-sync.yml
+++ b/.github/workflows/gitops-sync.yml
@@ -35,9 +35,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   sync:
-    # Migrated to GitHub-hosted cloud runner. Self-hosted runner config preserved below.
-    # runs-on: [self-hosted, local-linux]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
     steps:
       - name: Validate the immutable image reference
         id: image


### PR DESCRIPTION
Routes reusable GitOps sync and GHCR retention jobs to the approved organization self-hosted runner pool. This removes the GitHub-hosted scheduling dependency that caused the service-ai deploy job to fail before running any step. Validation: git diff --check.