### PR TITLE
fix(ci): move cache-delta job to the self-hosted runner pool

### DIFF
--- a/.github/workflows/android-version-bump.yml
+++ b/.github/workflows/android-version-bump.yml
@@ -75,9 +75,10 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   bump:
-    # Migrated to GitHub-hosted cloud runner. Self-hosted runner config preserved below.
-    # runs-on: [self-hosted, local-linux]
-    runs-on: ubuntu-latest
+    # Uses the proven kooker1-org self-hosted pool (see org-runner-canary.yml in kooker-infra and
+    # maven-version-bump.yml/ghcr-retention.yml/gitops-sync.yml in this repo) -- not the retired
+    # [self-hosted, local-linux] label this job was moved off of.
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
     permissions:
       contents: write  # needed to push the bump commit back to the branch
 

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -26,9 +26,10 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   tag:
-    # Migrated to GitHub-hosted cloud runner. Self-hosted runner config preserved below.
-    # runs-on: [self-hosted, local-linux]
-    runs-on: ubuntu-latest
+    # Uses the proven kooker1-org self-hosted pool (see org-runner-canary.yml in kooker-infra and
+    # maven-version-bump.yml/ghcr-retention.yml/gitops-sync.yml in this repo) -- not the retired
+    # [self-hosted, local-linux] label this job was moved off of.
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
     # Serialise tag creation per-repo to prevent two concurrent merges computing
     # the same version tag and racing on 'git push origin $TAG'.
     # cancel-in-progress: false ensures the second run waits rather than dying.

--- a/.github/workflows/flyway-lint.yml
+++ b/.github/workflows/flyway-lint.yml
@@ -24,9 +24,10 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   lint:
-    # Migrated to GitHub-hosted cloud runner. Self-hosted runner config preserved below.
-    # runs-on: [self-hosted, local-linux]
-    runs-on: ubuntu-latest
+    # Uses the proven kooker1-org self-hosted pool (see org-runner-canary.yml in kooker-infra and
+    # maven-version-bump.yml/ghcr-retention.yml/gitops-sync.yml in this repo) -- not the retired
+    # [self-hosted, local-linux] label this job was moved off of.
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
     outputs:
       has_db_changes: ${{ steps.detect.outputs.has_db_changes }}
 

--- a/.github/workflows/neo4j-delta-cache.yml
+++ b/.github/workflows/neo4j-delta-cache.yml
@@ -49,9 +49,11 @@ env:
 jobs:
   cache-delta:
     name: Cache delta to Neo4j
-    # Migrated to GitHub-hosted cloud runner. Self-hosted runner config preserved below.
-    # runs-on: [self-hosted, local-linux]
-    runs-on: ubuntu-latest
+    # Moved off the GitHub-hosted cloud runner: the org Actions spending limit was blocking every
+    # GitHub-hosted job across several repos. Uses the proven kooker1-org self-hosted pool (see
+    # kooker-infra's org-runner-canary.yml and maven-version-bump.yml/ghcr-retention.yml/
+    # gitops-sync.yml in this repo), not the retired [self-hosted, local-linux] label above.
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/swagger-enforce.yml
+++ b/.github/workflows/swagger-enforce.yml
@@ -12,9 +12,10 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   validate-swagger:
-    # Migrated to GitHub-hosted cloud runner. Self-hosted runner config preserved below.
-    # runs-on: [self-hosted, local-linux]
-    runs-on: ubuntu-latest
+    # Uses the proven kooker1-org self-hosted pool (see org-runner-canary.yml in kooker-infra and
+    # maven-version-bump.yml/ghcr-retention.yml/gitops-sync.yml in this repo) -- not the retired
+    # [self-hosted, local-linux] label this job was moved off of.
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

`kooker-infra`'s "On Main Merge — Cache to Neo4j" (which calls this reusable
workflow) has failed on every recent `main` push with:

> The job was not started because an Actions budget is preventing further use.

Same org-wide Actions spending-limit exhaustion hitting several repos today.
Moves to the proven `kooker1-org` self-hosted pool already used by this
repo's `maven-version-bump.yml`/`ghcr-retention.yml`/`gitops-sync.yml` and
`kooker-infra`'s own `org-runner-canary.yml` — **not** the retired
`[self-hosted, local-linux]` label the prior comment referenced.

## All five ubuntu-latest jobs in this repo now migrated

`android-version-bump.yml`, `auto-version.yml`, `flyway-lint.yml`, and
`swagger-enforce.yml` carried the identical "Migrated to GitHub-hosted cloud
runner" comment and the same retired `[self-hosted, local-linux]` label —
same exposure to this budget issue. Operator decision (2026-07-20/21):
migrate all of them too rather than leave a mixed fleet. Added in a second
commit on this branch.

## Test plan

- [ ] Since these workflows are only invoked via `workflow_call`/push-to-main
      in the calling repos, the practical verification is each calling
      repo's next relevant push after this merges — the corresponding job
      should go green on the self-hosted runner instead of hitting the
      budget block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)