### PR TITLE
P1 - Shared GHCR image-existence gate + proof fixtures (fleet release contract, slice 1)

### DIFF
--- a/.github/workflows/verify-ghcr-image-fixtures.yml
+++ b/.github/workflows/verify-ghcr-image-fixtures.yml
@@ -1,0 +1,111 @@
+# =============================================================================
+# verify-ghcr-image-fixtures.yml
+# =============================================================================
+# PURPOSE
+#   Proof fixtures for verify-ghcr-image.yml: actually exercise the gate
+#   against one real, currently-published tag (must pass) and one tag that
+#   has never existed (must fail), then assert both outcomes landed the right
+#   way. Static YAML review can't prove a registry-inspection gate behaves
+#   correctly in both directions — this does, on every PR that touches either
+#   workflow, and on demand via workflow_dispatch.
+#
+#   The negative case can't call verify-ghcr-image.yml directly: GitHub
+#   Actions does not allow `continue-on-error` on a job that `uses:` a
+#   reusable workflow (only name/uses/with/secrets/needs/if/permissions are
+#   allowed there — confirmed with actionlint against this exact file), and
+#   without it the intentional failure would permanently red-flag this
+#   workflow as a required check. So the negative case re-runs the identical
+#   underlying command (`docker buildx imagetools inspect`) as an ordinary
+#   step with step-level continue-on-error, then asserts that step failed —
+#   proving the same mechanism the reusable workflow gates on, without the
+#   job itself reporting as a failed/blocking check.
+#
+#   Read-only: `docker buildx imagetools inspect` never mutates the registry.
+# =============================================================================
+
+name: Verify GHCR Image Gate — Proof Fixtures
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/verify-ghcr-image.yml'
+      - '.github/workflows/verify-ghcr-image-fixtures.yml'
+  workflow_dispatch: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+jobs:
+  known-good-tag-must-pass:
+    # Routed through the real reusable workflow — proves the whole call
+    # contract (inputs, auth, inspect) works end-to-end for a tag that
+    # genuinely exists.
+    uses: duikindiesee/kooker-workflows/.github/workflows/verify-ghcr-image.yml@main
+    with:
+      image_name: ghcr.io/duikindiesee/kooker-service-user
+      tag: '1.29.4'
+    secrets: inherit
+
+  known-bad-tag-must-fail:
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
+    steps:
+      - name: Authenticate to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.MAVEN_PUBLISH_TOKEN }}
+
+      - name: Set up Buildx for registry inspection
+        uses: docker/setup-buildx-action@v3
+
+      - name: Inspect a tag that was never published (expected to fail)
+        id: inspect
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect \
+            "ghcr.io/duikindiesee/kooker-service-user:0.0.0-verify-ghcr-image-fixture-never-published"
+
+      - name: Assert the inspection actually failed
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.inspect.outcome }}
+        run: |
+          set -euo pipefail
+          echo "inspect step outcome: ${OUTCOME}"
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "::error::docker buildx imagetools inspect accepted a tag that was never published (outcome: ${OUTCOME}) — the manifest-existence check is not enforcing."
+            exit 1
+          fi
+          echo "Confirmed: inspecting an absent tag fails, as verify-ghcr-image.yml relies on."
+
+  assert-fixture-outcomes:
+    needs: [known-good-tag-must-pass, known-bad-tag-must-fail]
+    if: always()
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
+    steps:
+      - name: Assert both fixture jobs landed as expected
+        shell: bash
+        env:
+          GOOD_RESULT: ${{ needs.known-good-tag-must-pass.result }}
+          BAD_RESULT: ${{ needs.known-bad-tag-must-fail.result }}
+        run: |
+          set -euo pipefail
+          echo "known-good-tag-must-pass => ${GOOD_RESULT}"
+          echo "known-bad-tag-must-fail  => ${BAD_RESULT}"
+
+          failed=0
+          if [[ "$GOOD_RESULT" != "success" ]]; then
+            echo "::error::verify-ghcr-image.yml rejected ghcr.io/duikindiesee/kooker-service-user:1.29.4, which genuinely exists (result: ${GOOD_RESULT})."
+            failed=1
+          fi
+          if [[ "$BAD_RESULT" != "success" ]]; then
+            echo "::error::the negative fixture job itself did not complete cleanly (result: ${BAD_RESULT}) — see its own steps for detail."
+            failed=1
+          fi
+
+          if [[ "$failed" -ne 0 ]]; then
+            exit 1
+          fi
+          echo "Proof fixtures confirm: the gate passes a real published tag, and inspecting an absent tag fails as the gate relies on."

--- a/.github/workflows/verify-ghcr-image-fixtures.yml
+++ b/.github/workflows/verify-ghcr-image-fixtures.yml
@@ -38,8 +38,12 @@ jobs:
   known-good-tag-must-pass:
     # Routed through the real reusable workflow — proves the whole call
     # contract (inputs, auth, inspect) works end-to-end for a tag that
-    # genuinely exists.
-    uses: duikindiesee/kooker-workflows/.github/workflows/verify-ghcr-image.yml@main
+    # genuinely exists. Local `./` reference (not `@main`) so this fixture
+    # exercises the version of the workflow in THIS PR, not whatever is
+    # already on main — a same-repo reusable-workflow call always resolves
+    # against the ref that triggered the run, which a full `owner/repo/...@main`
+    # reference cannot do for a workflow that doesn't exist on main yet.
+    uses: ./.github/workflows/verify-ghcr-image.yml
     with:
       image_name: ghcr.io/duikindiesee/kooker-service-user
       tag: '1.29.4'

--- a/.github/workflows/verify-ghcr-image.yml
+++ b/.github/workflows/verify-ghcr-image.yml
@@ -1,0 +1,109 @@
+# =============================================================================
+# verify-ghcr-image.yml
+# =============================================================================
+# PURPOSE
+#   Reusable "does this exact tag actually exist in GHCR" gate, extracted from
+#   gitops-sync.yml's own proven image-existence check (kooker-workflows #50)
+#   so a build-and-push workflow can call it immediately after pushing —
+#   catching a false-green release (built version != published tag, or the
+#   push silently failed) in the SAME run that built it, instead of only
+#   discovering it later when gitops-sync tries to deploy a tag that was
+#   never published.
+#
+#   This is the deterministic build-version contract's registry-verification
+#   step (see kooker-service-user PR #182), pulled into a shared, independently
+#   testable building block so every fleet consumer can call one proven step
+#   instead of hand-rolling `docker buildx imagetools inspect` per repo.
+#   gitops-sync.yml keeps its own copy of this same check as a second,
+#   independent gate at deploy time — defense in depth, not a replacement.
+#
+# USAGE (in calling workflow, right after the image push step)
+#   jobs:
+#     build-and-push:
+#       # ... build, tag and push the image ...
+#       outputs:
+#         new_version: ${{ steps.maven-version.outputs.version }}
+#
+#     verify-published:
+#       needs: build-and-push
+#       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+#       uses: duikindiesee/kooker-workflows/.github/workflows/verify-ghcr-image.yml@main
+#       with:
+#         image_name: ghcr.io/duikindiesee/kooker-service-user
+#         tag: ${{ needs.build-and-push.outputs.new_version }}
+#       secrets: inherit
+#
+#     deploy:
+#       needs: [build-and-push, verify-published]
+#       uses: duikindiesee/kooker-workflows/.github/workflows/gitops-sync.yml@main
+#       with:
+#         image_name: ghcr.io/duikindiesee/kooker-service-user
+#         new_tag: ${{ needs.build-and-push.outputs.new_version }}
+#         # ...
+#       secrets: inherit
+#
+# REQUIRED SECRETS
+#   MAVEN_PUBLISH_TOKEN — PAT with read access to GHCR for the calling repo's
+#   own packages (the same identity gitops-sync.yml authenticates with).
+# =============================================================================
+
+name: Verify GHCR Image Published
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: 'The base image name (e.g. ghcr.io/org/repo)'
+        required: true
+        type: string
+      tag:
+        description: 'The exact tag that must exist in the registry'
+        required: true
+        type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+jobs:
+  verify:
+    runs-on: [self-hosted, Linux, X64, kooker1-org, docker]
+    steps:
+      - name: Validate the immutable image reference
+        id: image
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$TAG" ]]; then
+            echo "::error::tag is empty — the caller's build job produced no version to verify."
+            exit 1
+          fi
+          if [[ ! "$IMAGE_NAME" =~ ^ghcr\.io/[a-z0-9_.-]+/[a-z0-9_./-]+$ ]]; then
+            echo "::error::image_name must be a lowercase ghcr.io image path"
+            exit 1
+          fi
+          if [[ ! "$TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "::error::tag is not a valid OCI tag"
+            exit 1
+          fi
+          echo "reference=${IMAGE_NAME}:${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.MAVEN_PUBLISH_TOKEN }}
+
+      - name: Set up Buildx for registry inspection
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prove the exact tag exists in the registry
+        shell: bash
+        env:
+          IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "$IMAGE_REFERENCE"
+          echo "Verified published image ${IMAGE_REFERENCE}."


### PR DESCRIPTION
## Summary

First bounded slice of enforcing one verified release version across the fleet (kooker-service-user PR #182's deterministic build-version contract). Per operator scope, this PR is limited to **shared workflow support and proof fixtures** in `kooker-workflows` — it does not touch any of the 8 consumer repos or deploy anything.

### What's here

- **`verify-ghcr-image.yml`** — new reusable `workflow_call` workflow that extracts the already-proven "validate → authenticate → buildx → `imagetools inspect`" sequence out of `gitops-sync.yml` (added there in #50) into a standalone gate a build-and-push job can call **immediately after pushing**, before `gitops-sync.yml` is ever invoked. This catches a false-green release (built version ≠ published tag, or the push silently failed) in the same run that produced it, instead of only discovering it later at deploy time. `gitops-sync.yml` keeps its own copy as an independent second gate — this is defense in depth, not a replacement.
- **`verify-ghcr-image-fixtures.yml`** — proof fixtures that actually exercise the gate: one job calls it with a real, currently-published tag (`ghcr.io/duikindiesee/kooker-service-user:1.29.4`, must pass); a second job runs the identical underlying `docker buildx imagetools inspect` command against a tag that has never existed (must fail, asserted via a step-level `continue-on-error` + outcome check — `continue-on-error` isn't permitted on a job that `uses:` a reusable workflow, confirmed with `actionlint`, so the negative case is structured as an ordinary job instead of a second `uses:` call to `verify-ghcr-image.yml`); a third job asserts both outcomes landed correctly. Runs on every PR touching either file — including this one — and via `workflow_dispatch`. Read-only throughout; `imagetools inspect` never mutates the registry.

### What's confirmed already done (not re-implemented here)

Re-checked the task's second requirement — "add a mandatory GHCR manifest-existence gate to the shared GitOps workflow" — against `gitops-sync.yml` on `main`: it already has this gate (`git log` shows PR #50, "fix(gitops): reject missing container images", already merged). `verify-ghcr-image.yml` reuses that exact logic rather than duplicating a second, possibly-drifting copy.

### Exact consumers still needing the per-repo migration (out of scope for this PR)

The remaining requirement — porting PR #182's *build-job-side* steps (checkout the immutable triggering SHA, apply the version-bump output to the build before packaging, cross-check the built artifact's version against the bump version, fail closed on mismatch) — has to live in each consumer's own build-and-push workflow, the same way PR #182 changed `kooker-service-user`'s `spring-boot-docker.yml` directly; `kooker-workflows` doesn't own that file. Confirmed repo names and current release cadence for all 8:

| Repo | Ecosystem | Workflow | Latest release |
|---|---|---|---|
| `kooker-service-auth` | Maven | `spring-boot-docker.yml` | v1.13.4 — 2026-07-21 |
| `kooker-service-ai` | Maven | `spring-boot-docker.yml` | v1.64.0 — 2026-07-20 |
| `kooker-service-ledger` | Maven | `spring-boot-docker.yml` | v1.7.1 — 2026-07-03 |
| `kooker-service-publishing` | Maven | `spring-boot-docker.yml` | v1.2.4 — 2026-06-25 |
| `kooker-discovery-service` | Maven | `spring-boot-docker.yml` | v1.0.14 — 2026-06-07 |
| `kooker-service-image` | Maven | `spring-boot-docker.yml` | v1.1.4 — 2026-06-07 |
| `kooker-service-venture` | Maven | `spring-boot-docker.yml` | v0.1.3 — 2026-06-07 |
| `sportifine-v2` | Node | `node-docker.yml` | v3.5.11 — 2026-06-28 |

**Suggested migration order** (highest release cadence / most exposure first, since every merge to `main` is one chance to hit the drift bug PR #182 fixed):

1. `kooker-service-auth` — released today, highest churn of the 8.
2. `kooker-service-ai` — released yesterday, near-daily release cadence.
3. `kooker-service-ledger` — moderate churn, financial-data service (high blast radius if a drifted deploy landed).
4. `kooker-service-publishing`
5. `kooker-discovery-service`
6. `kooker-service-image`
7. `kooker-service-venture` — lowest churn, pre-1.0.
8. `sportifine-v2` — last: it's the one Node consumer in the list (`node-version-bump.yml` + `npm version`, not `mvn versions:set`), so its steps need their own translation of PR #182's pattern rather than a literal copy; worth its own dedicated PR once the Maven repos have proven the pattern out.

Each of these repos' own `spring-boot-docker.yml`/`node-docker.yml` should additionally call this PR's new `verify-ghcr-image.yml` right after push, ahead of the `gitops-sync.yml` deploy call.

## Verification

- `actionlint .github/workflows/verify-ghcr-image.yml .github/workflows/verify-ghcr-image-fixtures.yml` — clean except the two pre-existing `kooker1-org`/`docker` custom-runner-label false positives that `gitops-sync.yml` (already on `main`) triggers identically (no `actionlint.yaml` in this repo defines those labels; confirmed by running actionlint against `gitops-sync.yml` itself for comparison).
- Hosted proof: `verify-ghcr-image-fixtures.yml` runs on this PR itself (paths filter matches both new files) — see PR checks.

## Scope guard

- Touched only `.github/workflows/**` in `kooker-workflows` (task `pathGlobs`).
- No consumer repos edited, no deploy, no merge/DONE by the executor.

Exact head: `0e9e2a21329a1392d41ea9396b8efeb9f4185a9d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)